### PR TITLE
Include dice sides in RollResult and RollResults

### DIFF
--- a/src/dice/FudgeDice.js
+++ b/src/dice/FudgeDice.js
@@ -81,7 +81,9 @@ class FudgeDice extends StandardDice {
       }
     }
 
-    return new RollResult(total);
+    const rollResult = new RollResult(total);
+    rollResult.sides = this.sides;
+    return rollResult;
   }
 }
 

--- a/src/dice/StandardDice.js
+++ b/src/dice/StandardDice.js
@@ -231,7 +231,9 @@ class StandardDice {
    * @returns {RollResult} The value rolled
    */
   rollOnce() {
-    return new RollResult(generator.integer(this.min, this.max));
+    const rollResult = new RollResult(generator.integer(this.min, this.max));
+    rollResult.sides = this.sides;
+    return rollResult;
   }
 
   /**

--- a/src/dice/StandardDice.js
+++ b/src/dice/StandardDice.js
@@ -220,6 +220,8 @@ class StandardDice {
       modifier.run(rollResult, this);
     });
 
+    rollResult.sides = this.sides;
+
     return rollResult;
   }
 

--- a/src/results/RollResult.js
+++ b/src/results/RollResult.js
@@ -6,7 +6,7 @@ const modifiersSymbol = Symbol('modifiers');
 const initialValueSymbol = Symbol('initial-value');
 const useInTotalSymbol = Symbol('use-in-total');
 const valueSymbol = Symbol('value');
-const sidesSymbol = Symbol('die');
+const sidesSymbol = Symbol('sides');
 
 /**
  * A `RollResult` represents the value and applicable modifiers for a single die roll

--- a/src/results/RollResult.js
+++ b/src/results/RollResult.js
@@ -6,6 +6,7 @@ const modifiersSymbol = Symbol('modifiers');
 const initialValueSymbol = Symbol('initial-value');
 const useInTotalSymbol = Symbol('use-in-total');
 const valueSymbol = Symbol('value');
+const sidesSymbol = Symbol('die');
 
 /**
  * A `RollResult` represents the value and applicable modifiers for a single die roll
@@ -222,6 +223,28 @@ class RollResult {
     }
 
     this[valueSymbol] = Number(value);
+  }
+
+  /**
+   * The sides of the type of die that was rolled.
+   *
+   * @returns {number|string}
+   */
+  get sides() {
+    return this[sidesSymbol];
+  }
+
+  /**
+   * Set the sides.
+   *
+   * @param {number|string} sides
+   */
+  set sides(sides) {
+    if (!sides || !(typeof sides === 'string' || typeof sides === 'number')) {
+      throw new TypeError(`die must be a string or number: ${sides}`);
+    }
+
+    this[sidesSymbol] = sides;
   }
 
   /**

--- a/src/results/RollResults.js
+++ b/src/results/RollResults.js
@@ -1,7 +1,7 @@
 import RollResult from './RollResult.js';
 
 const rollsSymbol = Symbol('rolls');
-const sidesSymbol = Symbol('die');
+const sidesSymbol = Symbol('sides');
 
 /**
  * A collection of die roll results

--- a/src/results/RollResults.js
+++ b/src/results/RollResults.js
@@ -1,6 +1,7 @@
 import RollResult from './RollResult.js';
 
 const rollsSymbol = Symbol('rolls');
+const sidesSymbol = Symbol('die');
 
 /**
  * A collection of die roll results
@@ -75,6 +76,28 @@ class RollResults {
     rolls.forEach((result) => {
       this.addRoll(result);
     });
+  }
+
+  /**
+   * The sides of the die that was rolled.
+   *
+   * @returns {number|string}
+   */
+  get sides() {
+    return this[sidesSymbol];
+  }
+
+  /**
+   * Set the sides.
+   *
+   * @param {number|string} sides
+   */
+  set sides(sides) {
+    if (!sides || !(typeof sides === 'string' || typeof sides === 'number')) {
+      throw new TypeError(`die must be a string or number: ${sides}`);
+    }
+
+    this[sidesSymbol] = sides;
   }
 
   /**

--- a/src/results/RollResults.js
+++ b/src/results/RollResults.js
@@ -79,7 +79,7 @@ class RollResults {
   }
 
   /**
-   * The sides of the die that was rolled.
+   * The sides of the type of die that was rolled.
    *
    * @returns {number|string}
    */

--- a/tests/DiceRoll.test.js
+++ b/tests/DiceRoll.test.js
@@ -175,11 +175,13 @@ describe('DiceRoll', () => {
       expect(results).toHaveLength(7);
 
       expect(results[0]).toBeInstanceOf(RollResults);
+      expect(results[0].sides).toBe(8);
       expect(results[1]).toBe('*');
       expect(results[2]).toBe('(');
       expect(results[3]).toBe(5);
       expect(results[4]).toBe('+');
       expect(results[5]).toBeInstanceOf(RollResults);
+      expect(results[5].sides).toBe(10);
       expect(results[6]).toBe(')');
     });
 

--- a/tests/dice/FudgeDice.test.js
+++ b/tests/dice/FudgeDice.test.js
@@ -322,7 +322,9 @@ describe('FudgeDice', () => {
 
   describe('Rolling', () => {
     test('rollOnce returns a RollResult object', () => {
-      expect((new FudgeDice(2, 1)).rollOnce()).toBeInstanceOf(RollResult);
+      const rollResult = new FudgeDice(2, 1).rollOnce();
+      expect(rollResult).toBeInstanceOf(RollResult);
+      expect(rollResult.sides).toBe('F.2');
     });
 
     test('rollOnce rolls between min and max (Inclusive)', () => {

--- a/tests/dice/FudgeDice.test.js
+++ b/tests/dice/FudgeDice.test.js
@@ -352,7 +352,9 @@ describe('FudgeDice', () => {
     });
 
     test('roll returns a RollResults object', () => {
-      expect((new FudgeDice(null, 1)).roll()).toBeInstanceOf(RollResults);
+      const rollResults = new FudgeDice(null, 1).roll();
+      expect(rollResults).toBeInstanceOf(RollResults);
+      expect(rollResults.sides).toBe('F.2');
     });
 
     test('rollOnce gets called when rolling', () => {

--- a/tests/dice/PercentileDice.test.js
+++ b/tests/dice/PercentileDice.test.js
@@ -300,7 +300,9 @@ describe('PercentileDice', () => {
 
   describe('Rolling', () => {
     test('rollOnce returns a RollResult object', () => {
-      expect((new PercentileDice()).rollOnce()).toBeInstanceOf(RollResult);
+      const rollResult = new PercentileDice().rollOnce();
+      expect(rollResult).toBeInstanceOf(RollResult);
+      expect(rollResult.sides).toBe('%');
     });
 
     test('rollOnce rolls between min and max (Inclusive)', () => {

--- a/tests/dice/PercentileDice.test.js
+++ b/tests/dice/PercentileDice.test.js
@@ -317,7 +317,9 @@ describe('PercentileDice', () => {
     });
 
     test('roll return a RollResults object', () => {
-      expect((new PercentileDice()).roll()).toBeInstanceOf(RollResults);
+      const rollResults = new PercentileDice().roll();
+      expect(rollResults).toBeInstanceOf(RollResults);
+      expect(rollResults.sides).toBe('%');
     });
 
     test('rollOnce gets called when rolling', () => {

--- a/tests/dice/StandardDice.test.js
+++ b/tests/dice/StandardDice.test.js
@@ -540,7 +540,9 @@ describe('StandardDice', () => {
 
   describe('Rolling', () => {
     test('rollOnce returns a RollResult object', () => {
-      expect((new StandardDice(6)).rollOnce()).toBeInstanceOf(RollResult);
+      const rollResult = new StandardDice(6).rollOnce();
+      expect(rollResult).toBeInstanceOf(RollResult);
+      expect(rollResult.sides).toBe(6);
     });
 
     test('rollOnce rolls between min and max (Inclusive)', () => {


### PR DESCRIPTION
When creating custom outputs for the dice roller, it's necessary to tell which type of die a `RollResult` (or `RollResults` object) was generated from. This PR adds a `sides` property to `RollResult` and `RollResults`. This property is populated when calling the `roll` or `rollOnce` methods on the standard, fudge, and percentile dice objects. Tests have been updated for each dice object and `RollResult`/`RollResults` to make sure the correct value is returned for `sides`.