### PR TITLE
Feature/279 enable changing of modifier execution order

### DIFF
--- a/src/modifiers/CriticalFailureModifier.js
+++ b/src/modifiers/CriticalFailureModifier.js
@@ -12,6 +12,13 @@ import ComparisonModifier from './ComparisonModifier.js';
  */
 class CriticalFailureModifier extends ComparisonModifier {
   /**
+   * The default modifier execution order.
+   *
+   * @type {number}
+   */
+  static order = 10;
+
+  /**
    * Create a `CriticalFailureModifier` instance.
    *
    * @param {ComparePoint} [comparePoint] The comparison object
@@ -20,9 +27,6 @@ class CriticalFailureModifier extends ComparisonModifier {
    */
   constructor(comparePoint) {
     super(comparePoint);
-
-    // set the modifier's sort order
-    this.order = 10;
   }
 
   /* eslint-disable class-methods-use-this */

--- a/src/modifiers/CriticalFailureModifier.js
+++ b/src/modifiers/CriticalFailureModifier.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-useless-constructor */
 import ComparisonModifier from './ComparisonModifier.js';
 
 /**

--- a/src/modifiers/CriticalSuccessModifier.js
+++ b/src/modifiers/CriticalSuccessModifier.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-useless-constructor */
 import ComparisonModifier from './ComparisonModifier.js';
 
 /**

--- a/src/modifiers/CriticalSuccessModifier.js
+++ b/src/modifiers/CriticalSuccessModifier.js
@@ -12,6 +12,13 @@ import ComparisonModifier from './ComparisonModifier.js';
  */
 class CriticalSuccessModifier extends ComparisonModifier {
   /**
+   * The default modifier execution order.
+   *
+   * @type {number}
+   */
+  static order = 9;
+
+  /**
    * Create a `CriticalSuccessModifier` instance.
    *
    * @param {ComparePoint} comparePoint The comparison object
@@ -20,9 +27,6 @@ class CriticalSuccessModifier extends ComparisonModifier {
    */
   constructor(comparePoint) {
     super(comparePoint);
-
-    // set the modifier's sort order
-    this.order = 9;
   }
 
   /* eslint-disable class-methods-use-this */

--- a/src/modifiers/DropModifier.js
+++ b/src/modifiers/DropModifier.js
@@ -9,6 +9,13 @@ import KeepModifier from './KeepModifier.js';
  */
 class DropModifier extends KeepModifier {
   /**
+   * The default modifier execution order.
+   *
+   * @type {number}
+   */
+  static order = 7;
+
+  /**
    * Create a `DropModifier` instance.
    *
    * @param {string} [end=l] Either `h|l` to drop highest or lowest
@@ -19,9 +26,6 @@ class DropModifier extends KeepModifier {
    */
   constructor(end = 'l', qty = 1) {
     super(end, qty);
-
-    // set the modifier's sort order
-    this.order = 7;
   }
 
   /**

--- a/src/modifiers/ExplodeModifier.js
+++ b/src/modifiers/ExplodeModifier.js
@@ -14,6 +14,13 @@ const penetrateSymbol = Symbol('penetrate');
  */
 class ExplodeModifier extends ComparisonModifier {
   /**
+   * The default modifier execution order.
+   *
+   * @type {number}
+   */
+  static order = 3;
+
+  /**
    * Create an `ExplodeModifier` instance
    *
    * @param {ComparePoint} [comparePoint=null] The comparison object
@@ -27,9 +34,6 @@ class ExplodeModifier extends ComparisonModifier {
 
     this[compoundSymbol] = !!compound;
     this[penetrateSymbol] = !!penetrate;
-
-    // set the modifier's sort order
-    this.order = 3;
   }
 
   /**

--- a/src/modifiers/KeepModifier.js
+++ b/src/modifiers/KeepModifier.js
@@ -16,6 +16,13 @@ const qtySymbol = Symbol('qty');
  */
 class KeepModifier extends Modifier {
   /**
+   * The default modifier execution order.
+   *
+   * @type {number}
+   */
+  static order = 6;
+
+  /**
    * Create a `KeepModifier` instance
    *
    * @param {string} [end=h] Either `h|l` to keep highest or lowest
@@ -29,9 +36,6 @@ class KeepModifier extends Modifier {
 
     this.end = end;
     this.qty = qty;
-
-    // set the modifier's sort order
-    this.order = 6;
   }
 
   /**

--- a/src/modifiers/MaxModifier.js
+++ b/src/modifiers/MaxModifier.js
@@ -14,6 +14,13 @@ const maxSymbol = Symbol('max');
  */
 class MaxModifier extends Modifier {
   /**
+   * The default modifier execution order.
+   *
+   * @type {number}
+   */
+  static order = 2;
+
+  /**
    * Create a `MaxModifier` instance.
    *
    * @param {number} max The maximum value
@@ -24,9 +31,6 @@ class MaxModifier extends Modifier {
     super();
 
     this.max = max;
-
-    // set the modifier's sort order
-    this.order = 2;
   }
 
   /**

--- a/src/modifiers/MinModifier.js
+++ b/src/modifiers/MinModifier.js
@@ -14,6 +14,13 @@ const minSymbol = Symbol('min');
  */
 class MinModifier extends Modifier {
   /**
+   * The default modifier execution order.
+   *
+   * @type {number}
+   */
+  static order = 1;
+
+  /**
    * Create a `MinModifier` instance.
    *
    * @param {number} min The minimum value
@@ -24,9 +31,6 @@ class MinModifier extends Modifier {
     super();
 
     this.min = min;
-
-    // set the modifier's sort order
-    this.order = 1;
   }
 
   /**

--- a/src/modifiers/Modifier.js
+++ b/src/modifiers/Modifier.js
@@ -5,11 +5,18 @@
  */
 class Modifier {
   /**
+   * The default modifier execution order.
+   *
+   * @type {number}
+   */
+  static order = 999;
+
+  /**
    * Create a `Modifier` instance.
    */
   constructor() {
     // set the modifier's sort order
-    this.order = 999;
+    this.order = this.constructor.order;
   }
 
   /* eslint-disable class-methods-use-this */

--- a/src/modifiers/ReRollModifier.js
+++ b/src/modifiers/ReRollModifier.js
@@ -13,6 +13,13 @@ const onceSymbol = Symbol('once');
  */
 class ReRollModifier extends ComparisonModifier {
   /**
+   * The default modifier execution order.
+   *
+   * @type {number}
+   */
+  static order = 4;
+
+  /**
    * Create a `ReRollModifier` instance.
    *
    * @param {boolean} [once=false] Whether to only re-roll once or not
@@ -22,9 +29,6 @@ class ReRollModifier extends ComparisonModifier {
     super(comparePoint);
 
     this.once = !!once;
-
-    // set the modifier's sort order
-    this.order = 4;
   }
 
   /* eslint-disable class-methods-use-this */

--- a/src/modifiers/SortingModifier.js
+++ b/src/modifiers/SortingModifier.js
@@ -11,6 +11,13 @@ const directionSymbol = Symbol('direction');
  */
 class SortingModifier extends Modifier {
   /**
+   * The default modifier execution order.
+   *
+   * @type {number}
+   */
+  static order = 11;
+
+  /**
    * Create a `SortingModifier` instance.
    *
    * @param {string} [direction=a] The direction to sort in; 'a' (Ascending) or 'd' (Descending)
@@ -21,9 +28,6 @@ class SortingModifier extends Modifier {
     super();
 
     this.direction = direction;
-
-    // set the modifier's sort order
-    this.order = 11;
   }
 
   /**

--- a/src/modifiers/TargetModifier.js
+++ b/src/modifiers/TargetModifier.js
@@ -15,6 +15,13 @@ const failureCPSymbol = Symbol('failure-cp');
  */
 class TargetModifier extends ComparisonModifier {
   /**
+   * The default modifier execution order.
+   *
+   * @type {number}
+   */
+  static order = 8;
+
+  /**
    * Create a `TargetModifier` instance.
    *
    * @param {ComparePoint} successCP The success comparison object
@@ -27,9 +34,6 @@ class TargetModifier extends ComparisonModifier {
 
     // set the failure compare point
     this.failureComparePoint = failureCP;
-
-    // set the modifier's sort order
-    this.order = 8;
   }
 
   /**

--- a/src/modifiers/UniqueModifier.js
+++ b/src/modifiers/UniqueModifier.js
@@ -16,6 +16,13 @@ const isDuplicate = (value, index, collection, notFirst = false) => {
  */
 class UniqueModifier extends ComparisonModifier {
   /**
+   * The default modifier execution order.
+   *
+   * @type {number}
+   */
+  static order = 5;
+
+  /**
    * Create a `UniqueModifier` instance.
    *
    * @param {boolean} [once=false] Whether to only re-roll once or not
@@ -25,9 +32,6 @@ class UniqueModifier extends ComparisonModifier {
     super(comparePoint);
 
     this.once = !!once;
-
-    // set the modifier's sort order
-    this.order = 5;
   }
 
   /* eslint-disable class-methods-use-this */

--- a/tests/modifiers/ComparisonModifier.test.js
+++ b/tests/modifiers/ComparisonModifier.test.js
@@ -14,6 +14,7 @@ describe('ComparisonModifier', () => {
         isComparePoint: expect.any(Function),
         name: 'comparison',
         notation: '',
+        order: expect.any(Number),
         toJSON: expect.any(Function),
         toString: expect.any(Function),
       }));

--- a/tests/modifiers/CriticalFailureModifier.test.js
+++ b/tests/modifiers/CriticalFailureModifier.test.js
@@ -15,6 +15,7 @@ describe('CriticalFailureModifier', () => {
         isComparePoint: expect.any(Function),
         name: 'critical-failure',
         notation: 'cf',
+        order: 10,
         toJSON: expect.any(Function),
         toString: expect.any(Function),
       }));

--- a/tests/modifiers/CriticalSuccessModifier.test.js
+++ b/tests/modifiers/CriticalSuccessModifier.test.js
@@ -15,6 +15,7 @@ describe('CriticalSuccessModifier', () => {
         isComparePoint: expect.any(Function),
         name: 'critical-success',
         notation: 'cs',
+        order: 9,
         toJSON: expect.any(Function),
         toString: expect.any(Function),
       }));

--- a/tests/modifiers/DropModifier.test.js
+++ b/tests/modifiers/DropModifier.test.js
@@ -16,6 +16,7 @@ describe('DropModifier', () => {
         end: 'l',
         name: 'drop-l',
         notation: 'dl1',
+        order: 7,
         run: expect.any(Function),
         toJSON: expect.any(Function),
         toString: expect.any(Function),

--- a/tests/modifiers/ExplodeModifier.test.js
+++ b/tests/modifiers/ExplodeModifier.test.js
@@ -20,6 +20,7 @@ describe('ExplodeModifier', () => {
         maxIterations: 1000,
         name: 'explode',
         notation: '!',
+        order: 3,
         run: expect.any(Function),
         toJSON: expect.any(Function),
         toString: expect.any(Function),

--- a/tests/modifiers/KeepModifier.test.js
+++ b/tests/modifiers/KeepModifier.test.js
@@ -16,6 +16,7 @@ describe('KeepModifier', () => {
         end: 'h',
         name: 'keep-h',
         notation: 'kh1',
+        order: 6,
         run: expect.any(Function),
         toJSON: expect.any(Function),
         toString: expect.any(Function),

--- a/tests/modifiers/MaxModifier.test.js
+++ b/tests/modifiers/MaxModifier.test.js
@@ -18,6 +18,7 @@ describe('MaxModifier', () => {
         max: 3,
         name: 'max',
         notation: 'max3',
+        order: 2,
         run: expect.any(Function),
         toJSON: expect.any(Function),
         toString: expect.any(Function),

--- a/tests/modifiers/MinModifier.test.js
+++ b/tests/modifiers/MinModifier.test.js
@@ -18,6 +18,7 @@ describe('MinModifier', () => {
         min: 3,
         name: 'min',
         notation: 'min3',
+        order: 1,
         run: expect.any(Function),
         toJSON: expect.any(Function),
         toString: expect.any(Function),

--- a/tests/modifiers/Modifier.test.js
+++ b/tests/modifiers/Modifier.test.js
@@ -3,112 +3,189 @@ import { Modifier } from '../../src/modifiers/index.js';
 import RollResults from '../../src/results/RollResults.js';
 
 describe('Modifier', () => {
-  let mod;
+  describe('Static', () => {
+    test('class structure', () => {
+      expect(Modifier.order).toEqual(expect.any(Number));
+      expect(Modifier.order).toBe(999);
+    });
 
-  beforeEach(() => {
-    mod = new Modifier();
-  });
+    describe('Order', () => {
+      test('can change to an integer', () => {
+        expect(Modifier.order).toBe(999);
 
-  describe('Initialisation', () => {
-    test('model structure', () => {
-      expect(mod).toBeInstanceOf(Modifier);
-      expect(mod).toEqual(expect.objectContaining({
-        maxIterations: 1000,
-        name: 'modifier',
-        notation: '',
-        order: 999,
-        run: expect.any(Function),
-        toJSON: expect.any(Function),
-        toString: expect.any(Function),
-      }));
+        Modifier.order = 1;
+        expect(Modifier.order).toBe(1);
+
+        Modifier.order = 0;
+        expect(Modifier.order).toBe(0);
+
+        Modifier.order = 45;
+        expect(Modifier.order).toBe(45);
+
+        Modifier.order = 4526;
+        expect(Modifier.order).toBe(4526);
+      });
+
+      test('can be negative', () => {
+        Modifier.order = -1;
+        expect(Modifier.order).toBe(-1);
+
+        Modifier.order = -37;
+        expect(Modifier.order).toBe(-37);
+
+        Modifier.order = -65837;
+        expect(Modifier.order).toBe(-65837);
+      });
+
+      test('can be float', () => {
+        Modifier.order = 0.12;
+        expect(Modifier.order).toBe(0.12);
+
+        Modifier.order = 678.2;
+        expect(Modifier.order).toBe(678.2);
+
+        Modifier.order = -1.62983;
+        expect(Modifier.order).toEqual(-1.62983);
+      });
     });
   });
 
-  describe('Order', () => {
-    test('can change to an integer', () => {
-      expect(mod.order).toBe(999);
+  describe('instance', () => {
+    let mod;
 
-      mod.order = 1;
-      expect(mod.order).toBe(1);
-
-      mod.order = 0;
-      expect(mod.order).toBe(0);
-
-      mod.order = 45;
-      expect(mod.order).toBe(45);
-
-      mod.order = 4526;
-      expect(mod.order).toBe(4526);
+    beforeEach(() => {
+      // reset the modifier order to the default
+      Modifier.order = 999;
+      mod = new Modifier();
     });
 
-    test('can be negative', () => {
-      mod.order = -1;
-      expect(mod.order).toBe(-1);
-
-      mod.order = -37;
-      expect(mod.order).toBe(-37);
-
-      mod.order = -65837;
-      expect(mod.order).toBe(-65837);
-    });
-
-    test('can be float', () => {
-      mod.order = 0.12;
-      expect(mod.order).toBe(0.12);
-
-      mod.order = 678.2;
-      expect(mod.order).toBe(678.2);
-
-      mod.order = -1.62983;
-      expect(mod.order).toEqual(-1.62983);
-    });
-
-    test('changing order for one instance does not affect others', () => {
-      const mod2 = new Modifier();
-
-      expect(mod.order).toBe(999);
-      expect(mod2.order).toBe(999);
-
-      mod2.order = 3;
-      expect(mod.order).toBe(999);
-      expect(mod2.order).toBe(3);
-
-      mod.order = 56;
-      expect(mod.order).toBe(56);
-      expect(mod2.order).toBe(3);
-    });
-  });
-
-  describe('Output', () => {
-    test('JSON output is correct', () => {
-      // json encode, to get the encoded string, then decode so we can compare the object
-      // this allows us to check that the output is correct, but ignoring the order of the
-      // returned properties
-      expect(JSON.parse(JSON.stringify(mod))).toEqual({
-        name: 'modifier',
-        notation: '',
-        type: 'modifier',
+    describe('Initialisation', () => {
+      test('model structure', () => {
+        expect(mod).toBeInstanceOf(Modifier);
+        expect(mod).toEqual(expect.objectContaining({
+          maxIterations: 1000,
+          name: 'modifier',
+          notation: '',
+          order: 999,
+          run: expect.any(Function),
+          toJSON: expect.any(Function),
+          toString: expect.any(Function),
+        }));
       });
     });
 
-    test('toString output is correct', () => {
-      expect(mod.toString()).toEqual('');
+    describe('Order', () => {
+      test('can change to an integer', () => {
+        expect(mod.order).toBe(999);
+
+        mod.order = 1;
+        expect(mod.order).toBe(1);
+
+        mod.order = 0;
+        expect(mod.order).toBe(0);
+
+        mod.order = 45;
+        expect(mod.order).toBe(45);
+
+        mod.order = 4526;
+        expect(mod.order).toBe(4526);
+      });
+
+      test('can be negative', () => {
+        mod.order = -1;
+        expect(mod.order).toBe(-1);
+
+        mod.order = -37;
+        expect(mod.order).toBe(-37);
+
+        mod.order = -65837;
+        expect(mod.order).toBe(-65837);
+      });
+
+      test('can be float', () => {
+        mod.order = 0.12;
+        expect(mod.order).toBe(0.12);
+
+        mod.order = 678.2;
+        expect(mod.order).toBe(678.2);
+
+        mod.order = -1.62983;
+        expect(mod.order).toEqual(-1.62983);
+      });
+
+      test('changing order for one instance does not affect others', () => {
+        const mod2 = new Modifier();
+
+        expect(mod.order).toBe(999);
+        expect(mod2.order).toBe(999);
+
+        mod2.order = 3;
+        expect(mod.order).toBe(999);
+        expect(mod2.order).toBe(3);
+
+        mod.order = 56;
+        expect(mod.order).toBe(56);
+        expect(mod2.order).toBe(3);
+      });
+
+      test('new instance uses current static order', () => {
+        Modifier.order = 2;
+        mod = new Modifier();
+        expect(mod.order).toBe(2);
+
+        Modifier.order = 5619;
+        mod = new Modifier();
+        expect(mod.order).toBe(5619);
+      });
+
+      test('changing static order does not change order for existing instances', () => {
+        expect(mod.order).toBe(999);
+
+        Modifier.order = 5;
+
+        expect(mod.order).toBe(999);
+      });
+
+      test('changing instance order does not change static order', () => {
+        expect(Modifier.order).toBe(999);
+
+        mod.order = 23;
+
+        expect(Modifier.order).toBe(999);
+      });
     });
-  });
 
-  describe('Run', () => {
-    let die;
-    let results;
+    describe('Output', () => {
+      test('JSON output is correct', () => {
+        // json encode, to get the encoded string, then decode so we can compare the object
+        // this allows us to check that the output is correct, but ignoring the order of the
+        // returned properties
+        expect(JSON.parse(JSON.stringify(mod))).toEqual({
+          name: 'modifier',
+          notation: '',
+          type: 'modifier',
+        });
+      });
 
-    beforeEach(() => {
-      results = new RollResults([
-        8, 4, 2, 1, 6, 10,
-      ]);
-      die = new StandardDice(10, 6);
+      test('toString output is correct', () => {
+        expect(mod.toString()).toEqual('');
+      });
     });
 
-    test('returns RollResults object', () => {
-      expect(mod.run(results, die)).toBe(results);
+    describe('Run', () => {
+      let die;
+      let results;
+
+      beforeEach(() => {
+        results = new RollResults([
+          8, 4, 2, 1, 6, 10,
+        ]);
+        die = new StandardDice(10, 6);
+      });
+
+      test('returns RollResults object', () => {
+        expect(mod.run(results, die)).toBe(results);
+      });
     });
   });
 });

--- a/tests/modifiers/Modifier.test.js
+++ b/tests/modifiers/Modifier.test.js
@@ -3,15 +3,20 @@ import { Modifier } from '../../src/modifiers/index.js';
 import RollResults from '../../src/results/RollResults.js';
 
 describe('Modifier', () => {
+  let mod;
+
+  beforeEach(() => {
+    mod = new Modifier();
+  });
+
   describe('Initialisation', () => {
     test('model structure', () => {
-      const mod = new Modifier();
-
       expect(mod).toBeInstanceOf(Modifier);
       expect(mod).toEqual(expect.objectContaining({
         maxIterations: 1000,
         name: 'modifier',
         notation: '',
+        order: 999,
         run: expect.any(Function),
         toJSON: expect.any(Function),
         toString: expect.any(Function),
@@ -19,10 +24,63 @@ describe('Modifier', () => {
     });
   });
 
+  describe('Order', () => {
+    test('can change to an integer', () => {
+      expect(mod.order).toBe(999);
+
+      mod.order = 1;
+      expect(mod.order).toBe(1);
+
+      mod.order = 0;
+      expect(mod.order).toBe(0);
+
+      mod.order = 45;
+      expect(mod.order).toBe(45);
+
+      mod.order = 4526;
+      expect(mod.order).toBe(4526);
+    });
+
+    test('can be negative', () => {
+      mod.order = -1;
+      expect(mod.order).toBe(-1);
+
+      mod.order = -37;
+      expect(mod.order).toBe(-37);
+
+      mod.order = -65837;
+      expect(mod.order).toBe(-65837);
+    });
+
+    test('can be float', () => {
+      mod.order = 0.12;
+      expect(mod.order).toBe(0.12);
+
+      mod.order = 678.2;
+      expect(mod.order).toBe(678.2);
+
+      mod.order = -1.62983;
+      expect(mod.order).toEqual(-1.62983);
+    });
+
+    test('changing order for one instance does not affect others', () => {
+      const mod2 = new Modifier();
+
+      expect(mod.order).toBe(999);
+      expect(mod2.order).toBe(999);
+
+      mod2.order = 3;
+      expect(mod.order).toBe(999);
+      expect(mod2.order).toBe(3);
+
+      mod.order = 56;
+      expect(mod.order).toBe(56);
+      expect(mod2.order).toBe(3);
+    });
+  });
+
   describe('Output', () => {
     test('JSON output is correct', () => {
-      const mod = new Modifier();
-
       // json encode, to get the encoded string, then decode so we can compare the object
       // this allows us to check that the output is correct, but ignoring the order of the
       // returned properties
@@ -34,14 +92,11 @@ describe('Modifier', () => {
     });
 
     test('toString output is correct', () => {
-      const mod = new Modifier();
-
       expect(mod.toString()).toEqual('');
     });
   });
 
   describe('Run', () => {
-    let mod;
     let die;
     let results;
 
@@ -50,7 +105,6 @@ describe('Modifier', () => {
         8, 4, 2, 1, 6, 10,
       ]);
       die = new StandardDice(10, 6);
-      mod = new Modifier();
     });
 
     test('returns RollResults object', () => {

--- a/tests/modifiers/ReRollModifier.test.js
+++ b/tests/modifiers/ReRollModifier.test.js
@@ -18,6 +18,7 @@ describe('ReRollModifier', () => {
         name: 're-roll',
         notation: 'r',
         once: false,
+        order: 4,
         run: expect.any(Function),
         toJSON: expect.any(Function),
         toString: expect.any(Function),

--- a/tests/modifiers/SortingModifier.test.js
+++ b/tests/modifiers/SortingModifier.test.js
@@ -16,6 +16,7 @@ describe('SortingModifier', () => {
         direction: 'a',
         name: 'sorting',
         notation: 'sa',
+        order: 11,
         run: expect.any(Function),
         toJSON: expect.any(Function),
         toString: expect.any(Function),

--- a/tests/modifiers/TargetModifier.test.js
+++ b/tests/modifiers/TargetModifier.test.js
@@ -28,6 +28,7 @@ describe('TargetModifier', () => {
         isSuccess: expect.any(Function),
         name: 'target',
         notation: '>8f<4',
+        order: 8,
         run: expect.any(Function),
         successComparePoint: sCP,
         toJSON: expect.any(Function),

--- a/tests/modifiers/UniqueModifier.test.js
+++ b/tests/modifiers/UniqueModifier.test.js
@@ -18,6 +18,7 @@ describe('UniqueModifier', () => {
         name: 'unique',
         notation: 'u',
         once: false,
+        order: 5,
         run: expect.any(Function),
         toJSON: expect.any(Function),
         toString: expect.any(Function),

--- a/tests/modifiers/modifiers.test.js
+++ b/tests/modifiers/modifiers.test.js
@@ -1,5 +1,13 @@
 import { StandardDice } from '../../src/dice/index.js';
 import DiceRoll from '../../src/DiceRoll.js';
+import {
+  DropModifier,
+  ExplodeModifier,
+  KeepModifier,
+  ReRollModifier,
+  UniqueModifier,
+} from '../../src/modifiers/index.js';
+import RollResult from '../../src/results/RollResult.js';
 
 describe('Modifiers', () => {
   test('does not duplicate drop modifier', () => {
@@ -57,5 +65,174 @@ describe('Modifiers', () => {
 
     // remove the spy
     spy.mockRestore();
+  });
+
+  describe('Modifier orders', () => {
+    const setOpenLegendOrder = () => {
+      KeepModifier.order = 3;
+      DropModifier.order = 4;
+      ExplodeModifier.order = 5;
+      ReRollModifier.order = 6;
+      UniqueModifier.order = 7;
+    };
+
+    const resetOrder = () => {
+      KeepModifier.order = 6;
+      DropModifier.order = 7;
+      ExplodeModifier.order = 3;
+      ReRollModifier.order = 4;
+      UniqueModifier.order = 5;
+    };
+
+    beforeEach(() => resetOrder());
+
+    test('can set modifier orders from function', () => {
+      setOpenLegendOrder();
+
+      expect(KeepModifier.order).toBe(3);
+      expect(DropModifier.order).toBe(4);
+      expect(ExplodeModifier.order).toBe(5);
+      expect(ReRollModifier.order).toBe(6);
+      expect(UniqueModifier.order).toBe(7);
+    });
+
+    test('can reset modifier orders from function', () => {
+      resetOrder();
+
+      expect(KeepModifier.order).toBe(6);
+      expect(DropModifier.order).toBe(7);
+      expect(ExplodeModifier.order).toBe(3);
+      expect(ReRollModifier.order).toBe(4);
+      expect(UniqueModifier.order).toBe(5);
+    });
+
+    describe('changing execution order', () => {
+      const notation = '8d4kh4!';
+
+      beforeEach(() => {
+        jest.spyOn(StandardDice.prototype, 'rollOnce')
+          .mockImplementationOnce(() => new RollResult(3))
+          .mockImplementationOnce(() => new RollResult(4))
+          .mockImplementationOnce(() => new RollResult(2))
+          .mockImplementationOnce(() => new RollResult(3))
+          .mockImplementationOnce(() => new RollResult(2))
+          .mockImplementationOnce(() => new RollResult(3))
+          .mockImplementationOnce(() => new RollResult(3))
+          .mockImplementationOnce(() => new RollResult(3))
+          .mockImplementationOnce(() => new RollResult(2));
+      });
+
+      test('default order executes explode before keep', () => {
+        const roll = new DiceRoll(notation);
+
+        expect(roll.total).toBe(13);
+        expect(roll.rolls).toHaveLength(1);
+
+        const { rolls } = roll.rolls[0];
+        expect(rolls).toHaveLength(9);
+
+        expect(rolls[0].calculationValue).toBe(3);
+        expect(rolls[0].value).toBe(3);
+        expect(rolls[0].useInTotal).toBe(false);
+        expect(rolls[0].modifiers).toEqual(new Set(['drop']));
+
+        expect(rolls[1].calculationValue).toBe(4);
+        expect(rolls[1].value).toBe(4);
+        expect(rolls[1].useInTotal).toBe(true);
+        expect(rolls[1].modifiers).toEqual(new Set(['explode']));
+
+        expect(rolls[2].calculationValue).toBe(2);
+        expect(rolls[2].value).toBe(2);
+        expect(rolls[2].useInTotal).toBe(false);
+        expect(rolls[2].modifiers).toEqual(new Set(['drop']));
+
+        expect(rolls[3].calculationValue).toBe(2);
+        expect(rolls[3].value).toBe(2);
+        expect(rolls[3].useInTotal).toBe(false);
+        expect(rolls[3].modifiers).toEqual(new Set(['drop']));
+
+        expect(rolls[4].calculationValue).toBe(3);
+        expect(rolls[4].value).toBe(3);
+        expect(rolls[4].useInTotal).toBe(false);
+        expect(rolls[4].modifiers).toEqual(new Set(['drop']));
+
+        expect(rolls[5].calculationValue).toBe(2);
+        expect(rolls[5].value).toBe(2);
+        expect(rolls[5].useInTotal).toBe(false);
+        expect(rolls[5].modifiers).toEqual(new Set(['drop']));
+
+        expect(rolls[6].calculationValue).toBe(3);
+        expect(rolls[6].value).toBe(3);
+        expect(rolls[6].useInTotal).toBe(true);
+        expect(rolls[6].modifiers).toEqual(new Set());
+
+        expect(rolls[7].calculationValue).toBe(3);
+        expect(rolls[7].value).toBe(3);
+        expect(rolls[7].useInTotal).toBe(true);
+        expect(rolls[7].modifiers).toEqual(new Set());
+
+        expect(rolls[8].calculationValue).toBe(3);
+        expect(rolls[8].value).toBe(3);
+        expect(rolls[8].useInTotal).toBe(true);
+        expect(rolls[8].modifiers).toEqual(new Set());
+      });
+
+      test('can change order so keep executes before explode', () => {
+        setOpenLegendOrder();
+
+        const roll = new DiceRoll(notation);
+
+        expect(roll.total).toBe(15);
+        expect(roll.rolls).toHaveLength(1);
+
+        const { rolls } = roll.rolls[0];
+        expect(rolls).toHaveLength(9);
+
+        expect(rolls[0].calculationValue).toBe(3);
+        expect(rolls[0].value).toBe(3);
+        expect(rolls[0].useInTotal).toBe(false);
+        expect(rolls[0].modifiers).toEqual(new Set(['drop']));
+
+        expect(rolls[1].calculationValue).toBe(4);
+        expect(rolls[1].value).toBe(4);
+        expect(rolls[1].useInTotal).toBe(true);
+        expect(rolls[1].modifiers).toEqual(new Set(['explode']));
+
+        expect(rolls[2].calculationValue).toBe(2);
+        expect(rolls[2].value).toBe(2);
+        expect(rolls[2].useInTotal).toBe(true);
+        expect(rolls[2].modifiers).toEqual(new Set());
+
+        expect(rolls[3].calculationValue).toBe(2);
+        expect(rolls[3].value).toBe(2);
+        expect(rolls[3].useInTotal).toBe(false);
+        expect(rolls[3].modifiers).toEqual(new Set(['drop']));
+
+        expect(rolls[4].calculationValue).toBe(3);
+        expect(rolls[4].value).toBe(3);
+        expect(rolls[4].useInTotal).toBe(false);
+        expect(rolls[4].modifiers).toEqual(new Set(['drop']));
+
+        expect(rolls[5].calculationValue).toBe(2);
+        expect(rolls[5].value).toBe(2);
+        expect(rolls[5].useInTotal).toBe(false);
+        expect(rolls[5].modifiers).toEqual(new Set(['drop']));
+
+        expect(rolls[6].calculationValue).toBe(3);
+        expect(rolls[6].value).toBe(3);
+        expect(rolls[6].useInTotal).toBe(true);
+        expect(rolls[6].modifiers).toEqual(new Set());
+
+        expect(rolls[7].calculationValue).toBe(3);
+        expect(rolls[7].value).toBe(3);
+        expect(rolls[7].useInTotal).toBe(true);
+        expect(rolls[7].modifiers).toEqual(new Set());
+
+        expect(rolls[8].calculationValue).toBe(3);
+        expect(rolls[8].value).toBe(3);
+        expect(rolls[8].useInTotal).toBe(true);
+        expect(rolls[8].modifiers).toEqual(new Set());
+      });
+    });
   });
 });


### PR DESCRIPTION
Resolves #279 by adding a customisable static `order` property to all modifiers.

When a modifier is instantiated, it uses the static `order` property to set the instance `order` property. The instance `order` property can still be changed per instance.