### PR TITLE
Add missing type export conditions and index.d.cts

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,6 +7,7 @@
 !/lib/*.map
 !/lib/**/*.map
 !/types/*.d.ts
+!/types/index.d.cts
 !/types/**/*.d.ts
 !CONTRIBUTING.md
 !licence.txt

--- a/package.json
+++ b/package.json
@@ -10,10 +10,17 @@
   "browser": "./lib/umd/bundle.js",
   "exports": {
     ".": {
-      "import": "./lib/esm/bundle.js",
-      "require": "./lib/umd/bundle.js"
+      "import": {
+        "types": "./types/index.d.ts",
+        "default": "./lib/esm/bundle.js"
+      },
+      "require": {
+        "types": "./types/index.d.cts",
+        "default": "./lib/umd/bundle.js"
+      }
     },
     "./lib/umd/bundle.js": {
+      "types": "./types/index.d.cts",
       "require": "./lib/umd/bundle.js"
     },
     "./src/": "./src/",
@@ -75,7 +82,7 @@
   },
   "scripts": {
     "build": "npm run build:dev && npm run build:prod && npm run build:declaration",
-    "build:declaration": "rm -rf types/ && tsc -p declaration.tsconfig.json",
+    "build:declaration": "rm -rf types/ && tsc -p declaration.tsconfig.json && cp ./types/index.d.ts ./types/index.d.cts",
     "build:dev": "npm run build:grammars && npm run lint && rollup --c --environment BUILD:dev",
     "build:grammars": "peggy -c ./peggy.config.cjs ./src/parser/grammars/grammar.pegjs",
     "build:prod": "npm run build:grammars && npm run lint && rollup --c --environment BUILD:prod",


### PR DESCRIPTION
While the library has types, it's missing the proper conditional `types` exports in `package.json` that causes any project using `node16` or `bundler` module resolution in Typescript to fail to build:

```
Could not find a declaration file for module '@dice-roller/rpg-dice-roller'. '<project>/node_modules/@dice-roller/rpg-dice-roller/lib/esm/bundle.js' implicitly has an 'any' type.
  There are types at '<project>/node_modules/@dice-roller/rpg-dice-roller/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@dice-roller/rpg-dice-roller' library may need to update its package.json or typings.
```

You can also see the types failing to resolve [here](https://arethetypeswrong.github.io/?p=%40dice-roller%2Frpg-dice-roller%405.4.0):
![image](https://github.com/dice-roller/rpg-dice-roller/assets/15206032/b50a17fa-b890-4f42-825d-e49bd6fdfd9a)

This PR adds in the missing `types` condition to `exports` (and a [required `index.d.cts` that's just a copy of `index.d.ts`](https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing)) so that Typescript is happy and can resolve types and compile:
![image](https://github.com/dice-roller/rpg-dice-roller/assets/15206032/ad21927c-01e9-49e3-a423-b9ded343ddd4)

Note that you'll still need `skipLibCheck: true` in `tsconfig.json` regardless of your module settings until #247 is fixed though.