### PR TITLE
Fix MIT license link in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -45,4 +45,4 @@ This dice roller has been released under the MIT licence, meaning you can do pre
 
 You **can** use it in commercial products.
 
-If the licence terminology in the licence.txt is confusing, check out this: https://www.tldrlegal.com/l/mit
+If the licence terminology in the licence.txt is confusing, check out this: https://www.tldrlegal.com/license/mit-license


### PR DESCRIPTION
The current link is redirecting to the home page of that site.

This updates the link to point to the current URL of the MIT license tl;dr.