### PR TITLE
Include dice in RollResult

### DIFF
--- a/src/dice/FudgeDice.js
+++ b/src/dice/FudgeDice.js
@@ -82,7 +82,9 @@ class FudgeDice extends StandardDice {
       }
     }
 
-    return new RollResult(total);
+    const rollResult = new RollResult(total);
+    rollResult.dice = this;
+    return rollResult;
   }
 }
 

--- a/src/dice/StandardDice.js
+++ b/src/dice/StandardDice.js
@@ -236,7 +236,9 @@ class StandardDice extends HasDescription {
    * @returns {RollResult} The value rolled
    */
   rollOnce() {
-    return new RollResult(generator.integer(this.min, this.max));
+    const rollResult = new RollResult(generator.integer(this.min, this.max));
+    rollResult.dice = this;
+    return rollResult;
   }
 
   /**

--- a/src/results/RollResult.js
+++ b/src/results/RollResult.js
@@ -5,6 +5,7 @@ const calculationValueSymbol = Symbol('calculation-value');
 const modifiersSymbol = Symbol('modifiers');
 const initialValueSymbol = Symbol('initial-value');
 const useInTotalSymbol = Symbol('use-in-total');
+const diceSymbol = Symbol('dice');
 const valueSymbol = Symbol('value');
 
 /**
@@ -194,6 +195,14 @@ class RollResult {
    */
   set useInTotal(value) {
     this[useInTotalSymbol] = !!value;
+  }
+
+  get dice() {
+    return this[diceSymbol];
+  }
+
+  set dice(value) {
+    this[diceSymbol] = value;
   }
 
   /**

--- a/src/results/RollResult.js
+++ b/src/results/RollResult.js
@@ -202,6 +202,10 @@ class RollResult {
   }
 
   set dice(value) {
+    if (typeof value !== 'object' || !value) {
+      throw new TypeError('Dice value is not of instance StandardDice');
+    }
+
     this[diceSymbol] = value;
   }
 

--- a/tests/dice/FudgeDice.test.js
+++ b/tests/dice/FudgeDice.test.js
@@ -468,7 +468,13 @@ describe('FudgeDice', () => {
 
   describe('Rolling', () => {
     test('rollOnce returns a RollResult object', () => {
-      expect((new FudgeDice(2, 1)).rollOnce()).toBeInstanceOf(RollResult);
+      const dice = new FudgeDice(2, 1);
+      const rollResult = dice.rollOnce();
+
+      expect(rollResult).toBeInstanceOf(RollResult);
+      expect(rollResult.dice).toBeInstanceOf(FudgeDice);
+      expect(rollResult.dice).toBe(dice);
+      expect(rollResult.dice.sides).toEqual('F.2');
     });
 
     test('rollOnce rolls between min and max (Inclusive)', () => {
@@ -498,7 +504,12 @@ describe('FudgeDice', () => {
     });
 
     test('roll returns a RollResults object', () => {
-      expect((new FudgeDice(null, 1)).roll()).toBeInstanceOf(RollResults);
+      const dice = new FudgeDice(null, 1);
+      const rollResults = dice.roll();
+
+      expect(rollResults).toBeInstanceOf(RollResults);
+      expect(rollResults).toHaveLength(1);
+      expect(rollResults.rolls[0].dice).toBe(dice);
     });
 
     test('rollOnce gets called when rolling', () => {

--- a/tests/dice/PercentileDice.test.js
+++ b/tests/dice/PercentileDice.test.js
@@ -452,7 +452,13 @@ describe('PercentileDice', () => {
 
   describe('Rolling', () => {
     test('rollOnce returns a RollResult object', () => {
-      expect((new PercentileDice()).rollOnce()).toBeInstanceOf(RollResult);
+      const dice = new PercentileDice();
+      const result = dice.rollOnce();
+
+      expect(result).toBeInstanceOf(RollResult);
+      expect(result.dice).toBeInstanceOf(PercentileDice);
+      expect(result.dice).toBe(dice);
+      expect(result.dice.sides).toEqual('%');
     });
 
     test('rollOnce rolls between min and max (Inclusive)', () => {
@@ -487,9 +493,11 @@ describe('PercentileDice', () => {
     });
 
     test('roll returns correct number of rolls', () => {
-      const die = new PercentileDice(4);
+      const dice = new PercentileDice(4);
+      const rollResults = dice.roll();
 
-      expect(die.roll()).toHaveLength(4);
+      expect(rollResults).toHaveLength(4);
+      expect(rollResults.rolls[0].dice).toBe(dice);
     });
   });
 


### PR DESCRIPTION
Its basically the same PR as https://github.com/dice-roller/rpg-dice-roller/pull/252 but I added a check inside the setter. 

Note that I only check for `typeof dice !== 'object'`
at first I had something like 

```JS
if (!(dice instanceof StandardDice)){
  ...
}
```

but then I got dependency cycle errors of eslint and I don't think we can solve them without some serious redesign or ugly hacks. So I only included the typeof check 